### PR TITLE
Fixed the incorrect placement of arguments in the indirect map file.

### DIFF
--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -9,18 +9,28 @@ define autofs::mount (
 
   if $mapfile != undef {
     $path = $mapfile
+    $swap_opts = true
   } else {
     $path = $autofs::params::master
+    $swap_opts = false
   }
 
   autofs::mapfile { "autofs::mount ${title}":
     path => $path
   }
 
-  concat::fragment { "autofs::mount ${path}:${mountpoint}":
-    target  => $path,
-    content => "$mountpoint $map $options\n",
-    order   => '100',
+  if $swap_opts {
+    concat::fragment { "autofs::mount ${path}:${mountpoint}":
+      target  => $path,
+      content => "$mountpoint $options $map\n",
+      order   => '100',
+    }
+  } else {
+    concat::fragment { "autofs::mount ${path}:${mountpoint}":
+      target  => $path,
+      content => "$mountpoint $map $options\n",
+      order   => '100',
+    }
   }
 
 }


### PR DESCRIPTION
I've assumed the only direct map file is the auto.master. I'm not sure of another way to easily distinguish the two.
