### PR TITLE
added concat resource and fixed puppet-lint errors

### DIFF
--- a/manifests/directmount.pp
+++ b/manifests/directmount.pp
@@ -19,8 +19,14 @@ define autofs::directmount (
     path => $path
   }
 
-  concat::fragment { "autofs::mount ${path}:${mountpoint}":
+  concat { $path:
     ensure  => $ensure,
+    owner  => $autofs::params::owner,
+    group  => $autofs::params::group,
+    mode  => '0644'
+  }
+
+  concat::fragment { "autofs::mount ${path}:${mountpoint}":
     target  => $path,
     content => "${mountpoint} ${options} ${location}\n",
     order   => '100',

--- a/manifests/directmount.pp
+++ b/manifests/directmount.pp
@@ -1,3 +1,5 @@
+#== Define: autofs::directmount
+
 define autofs::directmount (
   $location,
   $ensure     = 'present',
@@ -20,10 +22,10 @@ define autofs::directmount (
   }
 
   concat { $path:
-    ensure  => $ensure,
+    ensure => $ensure,
     owner  => $autofs::params::owner,
     group  => $autofs::params::group,
-    mode  => '0644'
+    mode   => '0644'
   }
 
   concat::fragment { "autofs::mount ${path}:${mountpoint}":

--- a/manifests/include.pp
+++ b/manifests/include.pp
@@ -1,3 +1,5 @@
+# == Define: autofs::include
+
 define autofs::include (
   $map     = $title,
   $mapfile = undef

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,3 +1,5 @@
+# == Define: autofs
+
 class autofs {
   include autofs::params
 

--- a/manifests/mapfile.pp
+++ b/manifests/mapfile.pp
@@ -1,3 +1,5 @@
+# == Define: autofs::mapfile
+
 define autofs::mapfile (
   $path
 ) {

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -21,8 +21,14 @@ define autofs::mount (
     path => $path
   }
 
-  concat::fragment { "autofs::mount ${path}:${mountpoint}":
+  concat { $path:
     ensure  => $ensure,
+    owner  => $autofs::params::owner,
+    group  => $autofs::params::group,
+    mode  => '0644'
+  }
+
+  concat::fragment { "autofs::mount ${path}:${mountpoint}":
     target  => $path,
     content => $content,
     order   => '100',

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -1,3 +1,5 @@
+# == Define: autofs::mount
+
 define autofs::mount (
   $map,
   $ensure     = present,
@@ -22,10 +24,10 @@ define autofs::mount (
   }
 
   concat { $path:
-    ensure  => $ensure,
+    ensure => $ensure,
     owner  => $autofs::params::owner,
     group  => $autofs::params::group,
-    mode  => '0644'
+    mode   => '0644'
   }
 
   concat::fragment { "autofs::mount ${path}:${mountpoint}":

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,3 +1,5 @@
+# == Define: autofs::params
+
 class autofs::params {
 
   case $::osfamily {


### PR DESCRIPTION
Current setup is PE 3.8 and puppetlabs/concat 1.2.1 when trying to run puppet apply the following error is thrown.

 - err: Failed to apply catalog: Could not find filebucket specified in backup

By creating the concat resource for the final file first seems to fix the issue.