### PR TITLE
Add define autofs::mapfile::line as concat::fragment wrapper

### DIFF
--- a/manifests/directmount.pp
+++ b/manifests/directmount.pp
@@ -5,33 +5,23 @@ define autofs::directmount (
   $ensure     = 'present',
   $mountpoint = $title,
   $options    = undef,
-  $mapfile    = undef
+  $mapfile    = undef,
+  $order      = undef,
 ) {
   include autofs
   include autofs::params
 
   if $mapfile != undef {
     validate_absolute_path($mapfile)
-    $path = $mapfile
+    $mapfile_real = $mapfile
   } else {
-    $path = $autofs::params::master
+    $mapfile_real = $autofs::params::master
   }
 
-  autofs::mapfile { "autofs::mount ${title}":
-    path => $path
-  }
-
-  concat { $path:
-    ensure => $ensure,
-    owner  => $autofs::params::owner,
-    group  => $autofs::params::group,
-    mode   => '0644'
-  }
-
-  concat::fragment { "autofs::mount ${path}:${mountpoint}":
-    target  => $path,
+  autofs::mapfile::line { "autofs::mount ${mapfile_real}:${mountpoint}":
+    mapfile => $mapfile_real,
     content => "${mountpoint} ${options} ${location}\n",
-    order   => '100',
+    order   => $order,
   }
 
 }

--- a/manifests/include.pp
+++ b/manifests/include.pp
@@ -2,26 +2,23 @@
 
 define autofs::include (
   $map     = $title,
-  $mapfile = undef
+  $mapfile = undef,
+  $order   = '200',
 ) {
   include autofs
   include autofs::params
 
   if $mapfile != undef {
     validate_absolute_path($mapfile)
-    $path = $mapfile
+    $mapfile_real = $mapfile
   } else {
-    $path = $autofs::params::master
+    $mapfile_real = $autofs::params::master
   }
 
-  autofs::mapfile { "autofs::include ${title}":
-    path => $path
-  }
-
-  concat::fragment { "autofs::include ${title}":
-    target  => $path,
+  autofs::mapfile::line { "autofs::include ${title}":
+    mapfile => $mapfile_real,
     content => "+${map}\n",
-    order   => '200',
+    order   => $order,
   }
 
 }

--- a/manifests/mapfile/line.pp
+++ b/manifests/mapfile/line.pp
@@ -1,0 +1,19 @@
+# == Define: autofs::mapfile::line
+define autofs::mapfile::line (
+  $mapfile,
+  $content,
+  $order = '100',
+) {
+
+  autofs::mapfile { "autofs::mount ${title}":
+    path => $mapfile
+  }
+
+  concat::fragment { $title:
+    target  => $mapfile,
+    content => $content,
+    order   => $order,
+  }
+
+
+}

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -5,35 +5,25 @@ define autofs::mount (
   $ensure     = present,
   $mountpoint = $title,
   $options    = undef,
-  $mapfile    = undef
+  $mapfile    = undef,
+  $order      = undef,
 ) {
   include autofs
   include autofs::params
 
   if $mapfile != undef {
     validate_absolute_path($mapfile)
-    $path = $mapfile
+    $mapfile_real = $mapfile
     $content = "${mountpoint} ${options} ${map}\n"
   } else {
-    $path = $autofs::params::master
+    $mapfile_real = $autofs::params::master
     $content = "${mountpoint} ${map} ${options}\n"
   }
 
-  autofs::mapfile { "autofs::mount ${title}":
-    path => $path
-  }
-
-  concat { $path:
-    ensure => $ensure,
-    owner  => $autofs::params::owner,
-    group  => $autofs::params::group,
-    mode   => '0644'
-  }
-
-  concat::fragment { "autofs::mount ${path}:${mountpoint}":
-    target  => $path,
+  autofs::mapfile::line { "autofs::mount ${mapfile_real}:${mountpoint}":
+    mapfile => $mapfile_real,
     content => $content,
-    order   => '100',
+    order   => $order,
   }
 
 }


### PR DESCRIPTION
Adds order parameter passed to concat::fragment to autofs::mount, autofs::directmount, autofs::include. Defaults to '100' except for autofs::include where it is '200'.

Fixes #19 

Maybe helps with #12 